### PR TITLE
Feat/kick party member: 추방하기 기능 추가

### DIFF
--- a/src/api/member-api.ts
+++ b/src/api/member-api.ts
@@ -18,8 +18,8 @@ export const requestJoinParty = async (partyId: string) => {
   if (error) throw new Error(error.message);
 };
 
-// api - 참가신청 취소
-export const cancelJoinRequest = async (partyId: string, userId: string) => {
+// api - 참가자 본인: 참가신청 취소, 파티장: 추방
+export const removePartyMember = async (partyId: string, userId: string) => {
   const client = createClient();
 
   const { error } = await client

--- a/src/components/profile/JoiningParty.tsx
+++ b/src/components/profile/JoiningParty.tsx
@@ -3,11 +3,11 @@ import { useJoinedPartiesQuery } from '@/query/member/usePartyMemberQuery';
 import QueryStateWrapper from '../QueryStateWrapper';
 import PartyList from '../recruit/PartyList';
 
-interface JoinedPartyProps {
+interface JoiningPartyProps {
   userId: string;
 }
 
-const JoinedParty = ({ userId }: JoinedPartyProps) => {
+const JoiningParty = ({ userId }: JoiningPartyProps) => {
   const { data, isLoading, error } = useJoinedPartiesQuery(userId);
 
   return (
@@ -17,4 +17,4 @@ const JoinedParty = ({ userId }: JoinedPartyProps) => {
   );
 };
 
-export default JoinedParty;
+export default JoiningParty;

--- a/src/components/profile/ProfileTabsContents.tsx
+++ b/src/components/profile/ProfileTabsContents.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TabsContent } from '../ui/tabs';
 import ProfileIntro from './ProfileIntro';
-import JoinedParty from './JoinedParty';
+import JoiningParty from './JoiningParty';
 import CreatedParties from './CreatedParties';
 
 interface ProfileTabsContentsProps {
@@ -15,7 +15,7 @@ const ProfileTabsContents = ({ userId }: ProfileTabsContentsProps) => {
         <ProfileIntro userId={userId} />
       </TabsContent>
       <TabsContent value="joined">
-        <JoinedParty userId={userId} />
+        <JoiningParty userId={userId} />
       </TabsContent>
       <TabsContent value="created">
         <CreatedParties userId={userId} />

--- a/src/components/recruit/PartyDetail.tsx
+++ b/src/components/recruit/PartyDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useAuthQuery } from '@/query/auth/useAuthQuery';
 import {
-  useCancelJoinRequestMutation,
+  useRemovePartyMemberMutation,
   useRequestJoinPartyMutation,
 } from '@/query/member/usePartyMemberMutation';
 import {
@@ -13,7 +13,7 @@ import {
   useRaisePartyMutation,
 } from '@/query/party/usePartyMutation';
 import { RecruitWithProfile } from '@/types/parties.types';
-import { MoveUp, Pencil, Trash2 } from 'lucide-react';
+import { Loader2Icon, MoveUp, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import PartyRecruitForm from '../PartyRecruitForm';
 import TooltipWrapper from '../TooltipWrapper';
@@ -43,19 +43,17 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
 
   // 로그인 사용자
   const { data: currentUser } = useAuthQuery();
-  const userId = currentUser?.id || '';
+  const currentUserId = currentUser?.id || '';
 
   // 참가 신청한 파티인지 확인
-  const { data: isJoined } = useHasJoinedPartyQuery(recruit.id, userId);
+  const { data: isJoined } = useHasJoinedPartyQuery(recruit.id, currentUserId);
 
   // 참가 신청
-  const { mutate: requestJoin } = useRequestJoinPartyMutation(
-    recruit.id,
-    userId
-  );
+  const { mutate: requestJoin, isPending: isJoining } =
+    useRequestJoinPartyMutation(recruit.id, currentUserId);
 
-  // 참가 취소
-  const { mutate: cancelJoin } = useCancelJoinRequestMutation();
+  // 참가 취소 & 추방
+  const { mutate: removeMember, isPending } = useRemovePartyMemberMutation();
 
   // 구인글 삭제
   const { mutate: deleteRecruit } = useDeleteRecruitMutation();
@@ -64,7 +62,7 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
   const { mutate: raiseParty } = useRaisePartyMutation();
 
   // 로그인한 사용자가 작성자인지 확인
-  const isOwner = recruit.created_by.id === userId;
+  const isOwner = recruit.created_by.id === currentUserId;
 
   // 구인글 삭제 핸들러
   const handleDeleteRecruit = () => {
@@ -88,6 +86,17 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
     if (!ok) return toast.warning(`${wait}분 후에 끌어올릴 수 있습니다.`);
 
     raiseParty(recruit.id);
+  };
+
+  // 참가취소 & 추방하기 핸들러
+  const handleRemoveMember = (userId: string, isSelf: boolean) => {
+    const confirmMessage = isSelf
+      ? '참가를 취소하시겠습니까?'
+      : '추방하시겠습니까?';
+
+    if (!confirm(confirmMessage)) return;
+
+    removeMember({ partyId: recruit.id, userId });
   };
 
   return (
@@ -128,7 +137,7 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
           <h3 className="text-lg font-bold mb-4">참가자 목록</h3>
           <ul className="space-y-4">
             {partyMembers?.map((member) => (
-              <li key={member.id}>
+              <li key={member.id} className="flex items-center justify-between">
                 <Link
                   href={`/profile/${member.profile_id.id}`}
                   className="flex flex-row gap-2 items-center text-gray-800 font-semibold hover:bg-gray-200"
@@ -136,6 +145,20 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
                   <ProfileAvatar profileImg={member.profile_id.avatar_url} />
                   {member.profile_id.username}
                 </Link>
+                {/* 추방하기 버튼(작성자만 보이고 작성자 본인은 추방x) */}
+                {isOwner && currentUserId !== member.profile_id.id && (
+                  <Button
+                    onClick={() =>
+                      handleRemoveMember(member.profile_id.id, false)
+                    }
+                    disabled={isPending}
+                    variant="link"
+                    className="text-sm text-red-500"
+                  >
+                    {isPending && <Loader2Icon className="animate-spin" />}
+                    추방
+                  </Button>
+                )}
               </li>
             ))}
           </ul>
@@ -173,10 +196,12 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
             {/* 참가 취소 버튼 */}
             {!isOwner && isJoined && (
               <Button
-                onClick={() => cancelJoin({ partyId: recruit.id, userId })}
+                onClick={() => handleRemoveMember(currentUserId, true)}
+                disabled={isPending}
                 variant="outline"
                 className="px-4 py-2 border border-gray-400 text-gray-700 hover:bg-gray-100"
               >
+                {isPending && <Loader2Icon className="animate-spin" />}
                 참가 취소
               </Button>
             )}
@@ -185,8 +210,10 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
             {!isOwner && !isJoined && (
               <Button
                 onClick={() => requestJoin(recruit.id)}
+                disabled={isJoining}
                 className="px-4 py-2 bg-green-600 hover:bg-green-700"
               >
+                {isJoining && <Loader2Icon className="animate-spin" />}
                 참가 신청
               </Button>
             )}

--- a/src/query/member/usePartyMemberMutation.tsx
+++ b/src/query/member/usePartyMemberMutation.tsx
@@ -1,4 +1,4 @@
-import { cancelJoinRequest, requestJoinParty } from '@/api/member-api';
+import { removePartyMember, requestJoinParty } from '@/api/member-api';
 import { PartyMember } from '@/types/parties.types';
 import { Profile } from '@/types/profiles.types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -42,13 +42,13 @@ interface PartyMemberMutationParams {
   userId: PartyMember['profile_id'];
 }
 
-// 참가신청 취소
-export const useCancelJoinRequestMutation = () => {
+// 참가신청 취소 or 참가자 추방
+export const useRemovePartyMemberMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ partyId, userId }: PartyMemberMutationParams) =>
-      cancelJoinRequest(partyId, userId),
+      removePartyMember(partyId, userId),
     onSuccess: (_, variables) => {
       const { partyId, userId } = variables; // mutate 인자
 
@@ -61,7 +61,7 @@ export const useCancelJoinRequestMutation = () => {
       });
 
       queryClient.invalidateQueries({
-        queryKey: ['isJoined', partyId, userId], // 참가 여부
+        queryKey: ['isJoined', partyId, userId], // 해당 파티 참가 여부
       });
     },
   });


### PR DESCRIPTION
기존에 있던 참가신청 취소 로직 (api, mutation훅)을 사용하여 추방하기 기능 구현

네이밍 변경
- cancelJoinRequest → removePartyMember
- 참가신청 취소 → 참가신청 취소 + 추방하기


참가자 본인일 경우 → 참가신청 취소
작성자일경우 → 추방하기