### PR TITLE
Feat/party member: 파티 참가 인원 제한 추가 (참가 신청)

### DIFF
--- a/src/api/member-api.ts
+++ b/src/api/member-api.ts
@@ -11,6 +11,15 @@ import { createClient } from '@/utils/supabase/client';
 export const requestJoinParty = async (partyId: string) => {
   const client = createClient();
 
+  // 현재 참가자 수 조회(6명 제한)
+  const { count, error: countError } = await client
+    .from('party_member')
+    .select('*', { count: 'exact', head: true })
+    .eq('party_id', partyId);
+
+  if ((count ?? 0) >= 6) throw new Error(countError?.message);
+
+  // 참가자 테이블에 데이터 삽입
   const { error } = await client
     .from('party_member')
     .insert({ party_id: partyId });

--- a/src/components/recruit/PartyDetail.tsx
+++ b/src/components/recruit/PartyDetail.tsx
@@ -38,8 +38,7 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
   const [isEditOpen, setIsEditOpen] = useState(false);
 
   // 참가 중인 멤버
-  const { data: partyMembers, error } = usePartyMembersQuery(recruit.id);
-  if (error) console.log('error', error);
+  const { data: partyMembers } = usePartyMembersQuery(recruit.id);
 
   // 로그인 사용자
   const { data: currentUser } = useAuthQuery();
@@ -86,6 +85,14 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
     if (!ok) return toast.warning(`${wait}분 후에 끌어올릴 수 있습니다.`);
 
     raiseParty(recruit.id);
+  };
+
+  // 참가하기 핸들러
+  const handleRequestJoin = () => {
+    if (partyMembers?.length ?? 0 >= 6)
+      return toast.error('최대 인원(6명)이 찼습니다.');
+
+    requestJoin(recruit.id);
   };
 
   // 참가취소 & 추방하기 핸들러
@@ -209,7 +216,7 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
             {/* 참가 신청 버튼 */}
             {!isOwner && !isJoined && (
               <Button
-                onClick={() => requestJoin(recruit.id)}
+                onClick={handleRequestJoin}
                 disabled={isJoining}
                 className="px-4 py-2 bg-green-600 hover:bg-green-700"
               >

--- a/src/components/recruit/PartyDetail.tsx
+++ b/src/components/recruit/PartyDetail.tsx
@@ -89,7 +89,7 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
 
   // 참가하기 핸들러
   const handleRequestJoin = () => {
-    if (partyMembers?.length ?? 0 >= 6)
+    if ((partyMembers?.length ?? 0) >= 6)
       return toast.error('최대 인원(6명)이 찼습니다.');
 
     requestJoin(recruit.id);


### PR DESCRIPTION
구인글 1개당 6명의 인원이 참가 할 수 있음. (작성자 포함)

- 기존 참가 신청 api로직에 supabase 쿼리에 count 옵션을 추가하여 개수만 가져오는 로직을 추가하여 검증
- 컴포넌트 내부에도 참가하기 핸들러에 인원 수 검증하는 로직 추가