### PR TITLE
Feat/profile: 프로필 편집 추가

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -100,7 +100,7 @@ export type Database = {
           id: string
           intro: string | null
           job: string | null
-          level: string | null
+          level: number | null
           social_name: string | null
           updated_at: string | null
           username: string | null
@@ -112,7 +112,7 @@ export type Database = {
           id: string
           intro?: string | null
           job?: string | null
-          level?: string | null
+          level?: number | null
           social_name?: string | null
           updated_at?: string | null
           username?: string | null
@@ -124,7 +124,7 @@ export type Database = {
           id?: string
           intro?: string | null
           job?: string | null
-          level?: string | null
+          level?: number | null
           social_name?: string | null
           updated_at?: string | null
           username?: string | null

--- a/database.types.ts
+++ b/database.types.ts
@@ -96,38 +96,38 @@ export type Database = {
       profiles: {
         Row: {
           avatar_url: string
-          full_name: string | null
+          full_name: string
           id: string
           intro: string | null
           job: string | null
           level: number | null
           social_name: string | null
           updated_at: string | null
-          username: string | null
+          username: string
           website: string | null
         }
         Insert: {
           avatar_url: string
-          full_name?: string | null
+          full_name: string
           id: string
           intro?: string | null
           job?: string | null
           level?: number | null
           social_name?: string | null
           updated_at?: string | null
-          username?: string | null
+          username: string
           website?: string | null
         }
         Update: {
           avatar_url?: string
-          full_name?: string | null
+          full_name?: string
           id?: string
           intro?: string | null
           job?: string | null
           level?: number | null
           social_name?: string | null
           updated_at?: string | null
-          username?: string | null
+          username?: string
           website?: string | null
         }
         Relationships: []

--- a/database.types.ts
+++ b/database.types.ts
@@ -99,6 +99,9 @@ export type Database = {
           full_name: string | null
           id: string
           intro: string | null
+          job: string | null
+          level: string | null
+          social_name: string | null
           updated_at: string | null
           username: string | null
           website: string | null
@@ -108,6 +111,9 @@ export type Database = {
           full_name?: string | null
           id: string
           intro?: string | null
+          job?: string | null
+          level?: string | null
+          social_name?: string | null
           updated_at?: string | null
           username?: string | null
           website?: string | null
@@ -117,6 +123,9 @@ export type Database = {
           full_name?: string | null
           id?: string
           intro?: string | null
+          job?: string | null
+          level?: string | null
+          social_name?: string | null
           updated_at?: string | null
           username?: string | null
           website?: string | null

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "gen": "supabase gen types typescript --project-id axtqmkrpgkjwqnewrldv > database.types.ts"
+    "gen": "pnpx supabase gen types typescript --project-id axtqmkrpgkjwqnewrldv > database.types.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/src/api/profile-api.ts
+++ b/src/api/profile-api.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@/types/profiles.types';
+import { Profile, ProfileForm } from '@/types/profiles.types';
 import { SupabaseDataBase } from '@/types/utils.types';
 import { createClient } from '@/utils/supabase/client';
 
@@ -27,6 +27,21 @@ export const updateUserIntro = async (
   const { error } = await client
     .from('profiles')
     .update({ intro: data })
+    .eq('id', userId);
+
+  if (error) throw new Error(error.message);
+};
+
+// api - 프로필 수정
+export const updateProfile = async (
+  userId: Profile['id'],
+  formData: ProfileForm
+) => {
+  const client = createClient();
+
+  const { error } = await client
+    .from('profiles')
+    .update(formData)
     .eq('id', userId);
 
   if (error) throw new Error(error.message);

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { getCurrentUser } from '@/api/auth-api';
 import { getJoinedParties } from '@/api/member-api';
 import { getCreatedParties } from '@/api/party-api';
 import { getUserProfile } from '@/api/profile-api';
@@ -21,6 +22,11 @@ const ProfilePage = async ({ params }: ProfilePageProps) => {
 
   const serverClient = createClient();
   const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['currentUser'],
+    queryFn: () => getCurrentUser(serverClient),
+  });
 
   await queryClient.prefetchQuery({
     queryKey: ['userProfile', userId],

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,7 @@
+import ProfileEditForm from '@/components/profile/ProfileEditForm';
+
+const SettingsPage = () => {
+  return <ProfileEditForm />;
+};
+
+export default SettingsPage;

--- a/src/components/profile/ProfileEditForm.tsx
+++ b/src/components/profile/ProfileEditForm.tsx
@@ -17,33 +17,39 @@ import { useProfileUpdateMutation } from '@/query/profile/useProfileMutation';
 import { useAuthQuery } from '@/query/auth/useAuthQuery';
 import { useProfileQuery } from '@/query/profile/useProfileQuery';
 import QueryStateWrapper from '../QueryStateWrapper';
+import { MSG } from '@/constants/messages';
+import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 
+// TODO: /schemas/... 경로로 분리
 const formSchema = z.object({
   username: z.string().min(2, {
-    message: '닉네임은 최소 2자 이상이어야 합니다.',
+    message: MSG.USERNAME.MIN, // zod4부터 message → error
   }),
   social_name: z.string(),
-  level: z.number().min(1).max(200),
+  level: z.coerce
+    .number({
+      message: MSG.LEVEL.TYPE,
+    })
+    .min(1, { message: MSG.LEVEL.MIN })
+    .max(200, { message: MSG.LEVEL.MAX }),
   job: z.string(),
 });
 
 const ProfileEditForm = () => {
+  const router = useRouter();
+
   const { data: user } = useAuthQuery();
   const { data: profile, isLoading, error } = useProfileQuery(user?.id ?? '');
   const { mutate: updateProfile } = useProfileUpdateMutation();
 
-  if (!profile) return <div>정보없음</div>;
-
-  const { username, social_name, level, job } = profile;
-
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      username: username,
-      social_name: social_name ?? '',
-      level: level ?? undefined,
-      job: job ?? '',
+      username: profile?.username,
+      social_name: profile?.social_name ?? '',
+      level: profile?.level ?? undefined,
+      job: profile?.job ?? '',
     },
   });
 
@@ -51,7 +57,15 @@ const ProfileEditForm = () => {
     console.log('formData', formData);
     if (!profile) return;
 
-    updateProfile({ userId: profile.id, formData });
+    updateProfile(
+      { userId: profile.id, formData },
+      {
+        onSuccess: () => {
+          toast.success('프로필 정보가 수정 되었습니다.');
+          router.back();
+        },
+      }
+    );
   };
 
   return (

--- a/src/components/profile/ProfileEditForm.tsx
+++ b/src/components/profile/ProfileEditForm.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import {
+  Form,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '../ui/form';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { useProfileUpdateMutation } from '@/query/profile/useProfileMutation';
+import { useAuthQuery } from '@/query/auth/useAuthQuery';
+import { useProfileQuery } from '@/query/profile/useProfileQuery';
+import QueryStateWrapper from '../QueryStateWrapper';
+import { useRouter } from 'next/navigation';
+
+const formSchema = z.object({
+  username: z.string().min(2, {
+    message: '닉네임은 최소 2자 이상이어야 합니다.',
+  }),
+  social_name: z.string(),
+  level: z.number().min(1).max(200),
+  job: z.string(),
+});
+
+const ProfileEditForm = () => {
+  const { data: user } = useAuthQuery();
+  const { data: profile, isLoading, error } = useProfileQuery(user?.id ?? '');
+  const { mutate: updateProfile } = useProfileUpdateMutation();
+
+  if (!profile) return <div>정보없음</div>;
+
+  const { username, social_name, level, job } = profile;
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username: username,
+      social_name: social_name ?? '',
+      level: level ?? undefined,
+      job: job ?? '',
+    },
+  });
+
+  const onSubmit = (formData: z.infer<typeof formSchema>) => {
+    console.log('formData', formData);
+    if (!profile) return;
+
+    updateProfile({ userId: profile.id, formData });
+  };
+
+  return (
+    <QueryStateWrapper isLoading={isLoading} error={error}>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          {/* 닉네임 */}
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>닉네임</FormLabel>
+                <Input placeholder="" {...field} />
+                <FormDescription>인게임 닉네임을 입력해주세요.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* 소셜 닉네임 */}
+          <FormField
+            control={form.control}
+            name="social_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>소셜 코드</FormLabel>
+                <Input placeholder="예: #abcd" {...field} />
+                <FormDescription>
+                  메이플 월드 프로필(소셜) 코드를 입력해주세요.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* 레벨 */}
+          <FormField
+            control={form.control}
+            name="level"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>레벨</FormLabel>
+                <Input placeholder="예: 123" {...field} />
+                <FormDescription>레벨을 입력해주세요.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* 직업 */}
+          <FormField
+            control={form.control}
+            name="job"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>직업</FormLabel>
+                <Input placeholder="예: 용기사" {...field} />
+                <FormDescription>직업을 입력해주세요.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button>저장</Button>
+        </form>
+      </Form>
+    </QueryStateWrapper>
+  );
+};
+
+export default ProfileEditForm;

--- a/src/components/profile/ProfileInfo.tsx
+++ b/src/components/profile/ProfileInfo.tsx
@@ -3,8 +3,6 @@
 import { useProfileQuery } from '@/query/profile/useProfileQuery';
 import { Copy } from 'lucide-react';
 import Image from 'next/image';
-import React from 'react';
-import { Button } from '../ui/button';
 import { toast } from 'sonner';
 import QueryStateWrapper from '../QueryStateWrapper';
 
@@ -16,17 +14,18 @@ const ProfileInfo = ({ userId }: ProfileInfoProps) => {
   const { data: user, isLoading, error } = useProfileQuery(userId);
   if (!user) return null;
 
-  // discord 사용자명 클릭 복사 핸들러
-  const handleCopy = () => {
-    if (!user.full_name) return toast.error('해당 사용자명이 없습니다.');
+  // 복사 핸들러
+  const handleCopy = (copyValue: string | null) => {
+    if (!copyValue) return toast.error('복사에 실패했습니다.');
 
-    navigator.clipboard.writeText(user.full_name);
+    navigator.clipboard.writeText(copyValue);
     toast.success('복사되었습니다');
   };
 
   return (
     <QueryStateWrapper isLoading={isLoading} error={error}>
       <section className="flex flex-row gap-10 pb-8">
+        {/* 프로필 이미지 */}
         <Image
           src={user?.avatar_url}
           alt="프로필 이미지"
@@ -34,17 +33,32 @@ const ProfileInfo = ({ userId }: ProfileInfoProps) => {
           width={128}
           height={128}
         />
-        <div className="flex flex-col justify-center gap-1">
+
+        {/* 프로필 정보 영역 */}
+        <div className="flex flex-col justify-center gap-2">
+          {/* 닉네임 */}
           <p className="text-xl font-bold text-gray-900">{user.username}</p>
-          <Button
-            onClick={handleCopy}
-            className="flex flex-row text-sm text-gray-500 transition-colors hover:text-blue-600 hover:underline"
-            variant="secondary"
+
+          {/* TODO: 사용자명 & 소셜 닉네임 공통 컴포넌트화 */}
+          {/* 디스코드 사용자명 */}
+          <div
+            onClick={() => handleCopy(user.full_name)}
+            className="flex items-center gap-1 cursor-pointer hover:text-blue-600"
           >
-            {user.full_name}
+            <p className="text-xs text-muted-foreground">디스코드 사용자명:</p>
+            <p className="text-sm font-medium">{user.full_name}</p>
             <Copy className="w-4 h-4" />
-          </Button>
-          <p className="text-xs">디스코드 사용자명 입니다.</p>
+          </div>
+
+          {/* 소셜 닉네임 */}
+          <div
+            onClick={() => handleCopy(user.social_name)}
+            className="flex items-center gap-1 cursor-pointer hover:text-blue-600"
+          >
+            <p className="text-xs text-muted-foreground">소셜 닉네임:</p>
+            <p className="text-sm font-medium">{user.social_name}</p>
+            <Copy className="w-4 h-4" />
+          </div>
         </div>
       </section>
     </QueryStateWrapper>

--- a/src/components/profile/ProfileInfo.tsx
+++ b/src/components/profile/ProfileInfo.tsx
@@ -5,13 +5,21 @@ import { Copy } from 'lucide-react';
 import Image from 'next/image';
 import { toast } from 'sonner';
 import QueryStateWrapper from '../QueryStateWrapper';
+import { useAuthQuery } from '@/query/auth/useAuthQuery';
+import { Button } from '../ui/button';
+import Link from 'next/link';
 
 interface ProfileInfoProps {
   userId: string;
 }
 
 const ProfileInfo = ({ userId }: ProfileInfoProps) => {
+  // 유저정보
   const { data: user, isLoading, error } = useProfileQuery(userId);
+
+  // 본인 프로필 페이지 구분
+  const { data: currentUser } = useAuthQuery();
+  const isOwner = userId === currentUser?.id;
   if (!user) return null;
 
   // 복사 핸들러
@@ -36,8 +44,17 @@ const ProfileInfo = ({ userId }: ProfileInfoProps) => {
 
         {/* 프로필 정보 영역 */}
         <div className="flex flex-col justify-center gap-2">
-          {/* 닉네임 */}
-          <p className="text-xl font-bold text-gray-900">{user.username}</p>
+          {/* 닉네임/레벨/직업 + 수정 버튼 */}
+          <div className="flex items-center gap-2">
+            <p className="text-xl font-bold text-gray-900">
+              {user.username}/{user.level ?? '레벨'}/{user.job ?? '직업'}
+            </p>
+            {isOwner && (
+              <Button size="sm" variant="outline" asChild>
+                <Link href={'/settings'}>프로필 편집</Link>
+              </Button>
+            )}
+          </div>
 
           {/* TODO: 사용자명 & 소셜 닉네임 공통 컴포넌트화 */}
           {/* 디스코드 사용자명 */}

--- a/src/components/profile/ProfileIntro.tsx
+++ b/src/components/profile/ProfileIntro.tsx
@@ -6,7 +6,7 @@ import { Edit } from 'lucide-react';
 import { useAuthQuery } from '@/query/auth/useAuthQuery';
 import { Textarea } from '../ui/textarea';
 import { useProfileQuery } from '@/query/profile/useProfileQuery';
-import { useProfileMutation } from '@/query/profile/useProfileMutation';
+import { useProfileIntroMutation } from '@/query/profile/useProfileMutation';
 import { Profile } from '@/types/profiles.types';
 import QueryStateWrapper from '../QueryStateWrapper';
 
@@ -30,7 +30,7 @@ const ProfileIntro = ({ userId }: ProfileIntroProps) => {
   const isOwner = userId === currentUser?.id;
 
   // 소개글 업데이트
-  const { mutate: updateIntro } = useProfileMutation(userId);
+  const { mutate: updateIntro } = useProfileIntroMutation(userId);
 
   const [isEdit, setIsEdit] = useState(false);
   const [intro, setIntro] = useState(user?.intro ?? ''); // 소개글 textarea 상태

--- a/src/components/recruit/PartyDetail.tsx
+++ b/src/components/recruit/PartyDetail.tsx
@@ -150,7 +150,8 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
                   className="flex flex-row gap-2 items-center text-gray-800 font-semibold hover:bg-gray-200"
                 >
                   <ProfileAvatar profileImg={member.profile_id.avatar_url} />
-                  {member.profile_id.username}
+                  {member.profile_id.username}/{member.profile_id.level}/
+                  {member.profile_id.job}
                 </Link>
                 {/* 추방하기 버튼(작성자만 보이고 작성자 본인은 추방x) */}
                 {isOwner && currentUserId !== member.profile_id.id && (

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,12 @@
+export const MSG = {
+  USERNAME: {
+    MIN: '닉네임은 최소 2자 이상이어야 합니다.',
+  },
+  SOCIAL: {},
+  LEVEL: {
+    TYPE: '숫자를 입력해 주세요.',
+    MIN: '1 이상이어야 합니다.',
+    MAX: '200 이하이어야 합니다.',
+  },
+  JOB: {},
+};

--- a/src/query/profile/useProfileMutation.tsx
+++ b/src/query/profile/useProfileMutation.tsx
@@ -40,8 +40,6 @@ export const useProfileUpdateMutation = () => {
     onSuccess: (_, variables) => {
       const { userId } = variables;
 
-      toast.success('프로필 정보가 수정 되었습니다.');
-
       queryClient.invalidateQueries({
         queryKey: ['userProfile', userId],
       });

--- a/src/query/profile/useProfileMutation.tsx
+++ b/src/query/profile/useProfileMutation.tsx
@@ -1,17 +1,17 @@
-import { updateUserIntro } from '@/api/profile-api';
-import { Profile } from '@/types/profiles.types';
+import { updateProfile, updateUserIntro } from '@/api/profile-api';
+import { Profile, ProfileForm } from '@/types/profiles.types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-interface useProfileMutationParams {
+interface useProfileIntroMutationParams {
   intro: Profile['intro'];
 }
 
-export const useProfileMutation = (userId: Profile['id']) => {
+export const useProfileIntroMutation = (userId: Profile['id']) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ intro }: useProfileMutationParams) =>
+    mutationFn: ({ intro }: useProfileIntroMutationParams) =>
       updateUserIntro(intro, userId),
     onSuccess: () => {
       toast.success('프로필 소개가 업데이트 되었습니다.');
@@ -22,6 +22,29 @@ export const useProfileMutation = (userId: Profile['id']) => {
     },
     onError: () => {
       toast.error('업데이트에 실패했습니다.');
+    },
+  });
+};
+
+interface useProfileMutationProps {
+  userId: Profile['id'];
+  formData: ProfileForm;
+}
+
+export const useProfileUpdateMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ userId, formData }: useProfileMutationProps) =>
+      updateProfile(userId, formData),
+    onSuccess: (_, variables) => {
+      const { userId } = variables;
+
+      toast.success('프로필 정보가 수정 되었습니다.');
+
+      queryClient.invalidateQueries({
+        queryKey: ['userProfile', userId],
+      });
     },
   });
 };

--- a/src/query/profile/useProfileQuery.ts
+++ b/src/query/profile/useProfileQuery.ts
@@ -9,5 +9,6 @@ export const useProfileQuery = (userId: Profile['id']) => {
   return useQuery({
     queryKey: ['userProfile', userId],
     queryFn: () => getUserProfile(browserClient, userId),
+    enabled: !!userId,
   });
 };

--- a/src/types/profiles.types.ts
+++ b/src/types/profiles.types.ts
@@ -1,3 +1,8 @@
 import { Tables } from '../../database.types';
 
 export type Profile = Tables<'profiles'>;
+
+export type ProfileForm = Pick<
+  Profile,
+  'job' | 'level' | 'social_name' | 'username'
+>;


### PR DESCRIPTION
레벨은 자주 바뀔 수 있기 때문에 플랫폼 내에서 관리히도록 프로필 편집 기능 추가

- level, job, social_name 컬럼추가
- usernam, full_name null 허용 X
- 프로필 및 참가자목록 UI에서 닉네임/레벨/직업 으로 표기
- react-hook-form + zod
- submit 성공시 토스트 알림 및 이전페이지 이동 (UI컴포넌트에서 처리)