### PR TITLE
refactor: CSR컴포넌트로 전환 및 유저 정보 예외처리

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,19 +1,21 @@
+'use client';
 import Link from 'next/link';
 
-import { getCurrentUser } from '@/api/auth-api';
-import { getUserProfile } from '@/api/profile-api';
-import { createClient } from '@/utils/supabase/server';
+import { useAuthQuery } from '@/query/auth/useAuthQuery';
+import { useProfileQuery } from '@/query/profile/useProfileQuery';
 import LoginButton from './auth/LoginButton';
 import UserDropdownButton from './auth/UserDropdownButton';
 import RecruitButton from './RecruitButton';
 
-const Header = async () => {
-  const client = createClient();
-  const user = await getCurrentUser(client); // 로그인 정보
+const Header = () => {
+  // auth 테이블 조회
+  const { data: user } = useAuthQuery();
 
-  if (!user) return <LoginButton />;
+  // 타입 에러 방지 (enabled로 실행 제어됨)
+  const userId = user?.id ?? '';
 
-  const profile = await getUserProfile(client, user?.id); // 사용자 정보
+  // profiles 테이블 조회
+  const { data: profile } = useProfileQuery(userId);
 
   return (
     <header className="w-full sticky top-0 bg-[#588157]">
@@ -26,7 +28,7 @@ const Header = async () => {
             파티찾기
           </Link>
           <Link
-            href={`/profile/${profile.id}?tab=created`}
+            href={`/profile/${profile?.id}?tab=created`}
             className="hover:text-[#E63946]"
           >
             내 모집글
@@ -34,7 +36,7 @@ const Header = async () => {
         </nav>
         <div className="flex items-center gap-6">
           <RecruitButton />
-          <UserDropdownButton profile={profile} />
+          {profile ? <UserDropdownButton profile={profile} /> : <LoginButton />}
           {/* <AuthHeader /> */}
         </div>
       </div>

--- a/src/query/profile/useProfileQuery.ts
+++ b/src/query/profile/useProfileQuery.ts
@@ -9,6 +9,6 @@ export const useProfileQuery = (userId: Profile['id']) => {
   return useQuery({
     queryKey: ['userProfile', userId],
     queryFn: () => getUserProfile(browserClient, userId),
-    enabled: !!userId,
+    enabled: !!userId, // userId가 있을 경우에만 실행
   });
 };


### PR DESCRIPTION
CSR Header 컴포넌트로 전환

로그인/프로필 정보가 Header 내 여러 위치에서 필요했기 때문에
중복된 쿼리 호출을 피하고 구조를 자연스럽게 하기 위해 CSR로 전환

SSR Header를 사용할 경우 링크와 로그인여부에 따른 버튼에 로그인/프로필 정보가 필요했기에
각 컴포넌트를 분리해야 했음. 그렇게 되면 각 컴포넌트에서 같은 useQuery가 중복됨.

실제로는 한번만 호출되지만 여러 곳에 배치되어 있어 자연스럽지 않다고 판단.

ps. feat/header 브랜치에서 작업 햇어야했나..