### PR TITLE
Feat/auth: 로그인검증 및 프로필관련링크 이동

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.53.2",
+    "react-icons": "^5.5.0",
     "sonner": "^2.0.3",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-hook-form:
         specifier: ^7.53.2
         version: 7.53.2(react@18.3.1)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@18.3.1)
       sonner:
         specifier: ^2.0.3
         version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2283,6 +2286,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5018,6 +5026,10 @@ snapshots:
       scheduler: 0.23.2
 
   react-hook-form@7.53.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-icons@5.5.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,3 +76,9 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@layer components {
+  .dropdown-item {
+    @apply flex w-full items-center px-2 py-1.5 text-sm cursor-pointer hover:bg-[#eaf5ea] hover:text-[#206030];
+  }
+}

--- a/src/app/login-required/page.tsx
+++ b/src/app/login-required/page.tsx
@@ -1,0 +1,14 @@
+import LoginButton from '@/components/auth/LoginButton';
+
+const LoginRequiredPage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center text-center">
+      <h1 className="text-3xl font-bold text-[#333333] mb-4">
+        로그인이 필요합니다.
+      </h1>
+      <LoginButton />
+    </div>
+  );
+};
+
+export default LoginRequiredPage;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,13 +27,8 @@ const Header = () => {
           <Link href={'/recruit'} className="hover:text-[#E63946]">
             파티찾기
           </Link>
-          <Link
-            href={`/profile/${profile?.id}?tab=created`}
-            className="hover:text-[#E63946]"
-          >
-            내 모집글
-          </Link>
         </nav>
+
         <div className="flex items-center gap-6">
           <RecruitButton />
           {profile ? <UserDropdownButton profile={profile} /> : <LoginButton />}

--- a/src/components/RecruitButton.tsx
+++ b/src/components/RecruitButton.tsx
@@ -1,19 +1,22 @@
 'use client';
 
-import { useState } from 'react';
-import { Button } from './ui/button';
-import PartyRecruitForm from './PartyRecruitForm';
 import { useAuthQuery } from '@/query/auth/useAuthQuery';
-import { toast } from 'sonner';
+import { requireLogin } from '@/utils/auth';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import PartyRecruitForm from './PartyRecruitForm';
+import { Button } from './ui/button';
 
 const RecruitButton = () => {
+  const router = useRouter();
   // 구인하기 폼 모달 상태
   const [isRecruitFormOpen, setIsRecruitFormOpen] = useState(false);
 
   const { data: user } = useAuthQuery();
 
+  // 로그인 유무 검증 핸들러
   const handleOpenRecruitForm = () => {
-    if (!user) return toast.error('로그인이 필요합니다.');
+    if (!requireLogin({ user, router })) return;
 
     setIsRecruitFormOpen(true);
   };

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useSigninMutation } from '@/query/auth/useAuthMutation';
 import { Button } from '../ui/button';
+import { FaDiscord } from 'react-icons/fa';
 
 const LoginButton = () => {
   const { mutate: signIn } = useSigninMutation();
@@ -10,6 +11,7 @@ const LoginButton = () => {
       onClick={() => signIn()}
       className="bg-[#588157] hover:bg-[#476947]"
     >
+      <FaDiscord />
       로그인
     </Button>
   );

--- a/src/components/auth/UserDropdownButton.tsx
+++ b/src/components/auth/UserDropdownButton.tsx
@@ -41,8 +41,29 @@ const UserDropdownButton = ({ profile }: UserDropdownButtonProps) => {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        <DropdownMenuItem>
-          <Link href={`/profile/${profile.id}`}>프로필</Link>
+        <DropdownMenuItem className="hover:text-[#206030]" asChild>
+          <Link
+            href={`/profile/${profile.id}`}
+            className="cursor-pointer hover:text-[#206030]"
+          >
+            프로필
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link
+            href={`/profile/${profile?.id}?tab=created`}
+            className="dropdown-item"
+          >
+            생성한 파티
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link
+            href={`/profile/${profile?.id}?tab=joined`}
+            className="dropdown-item"
+          >
+            참가중인 파티
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem>

--- a/src/components/profile/ProfileTabs.tsx
+++ b/src/components/profile/ProfileTabs.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import CreatedParties from './CreatedParties';
 import JoiningParty from './JoiningParty';
@@ -10,17 +10,26 @@ interface ProfileTabsProps {
 }
 
 const ProfileTabs = ({ userId }: ProfileTabsProps) => {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const tab = searchParams.get('tab') ?? 'intro';
 
+  // 탭변경 핸들러
+  const handleTabsChange = (value: string) => {
+    if (tab !== value)
+      router.replace(
+        `/profile/${userId}${value === 'intro' ? '' : `?tab=${value}`}`
+      );
+  };
+
   return (
-    <Tabs defaultValue={tab}>
+    <Tabs value={tab} onValueChange={handleTabsChange}>
       <TabsList className="border-b">
         <TabsTrigger value="intro" variant="underline">
           소개
         </TabsTrigger>
         <TabsTrigger value="joined" variant="underline">
-          참가 중인 파티
+          참가중인 파티
         </TabsTrigger>
         <TabsTrigger value="created" variant="underline">
           생성한 파티

--- a/src/components/recruit/PartyDetail.tsx
+++ b/src/components/recruit/PartyDetail.tsx
@@ -29,11 +29,14 @@ import { canRaiseParty } from '@/utils/time';
 import { toast } from 'sonner';
 import Link from 'next/link';
 import ProfileAvatar from '../ProfileAvatar';
+import { requireLogin } from '@/utils/auth';
+import { useRouter } from 'next/navigation';
 
 interface PartyDetailProps {
   recruit: RecruitWithProfile;
 }
 const PartyDetail = ({ recruit }: PartyDetailProps) => {
+  const router = useRouter();
   // 수정하기폼 모달 상태
   const [isEditOpen, setIsEditOpen] = useState(false);
 
@@ -89,6 +92,8 @@ const PartyDetail = ({ recruit }: PartyDetailProps) => {
 
   // 참가하기 핸들러
   const handleRequestJoin = () => {
+    if (!requireLogin({ user: currentUser, router })) return;
+
     if ((partyMembers?.length ?? 0) >= 6)
       return toast.error('최대 인원(6명)이 찼습니다.');
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,13 @@
+import { User } from '@supabase/supabase-js';
+import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
+interface requireLoginParams {
+  user: User | null | undefined;
+  router: AppRouterInstance;
+}
+// 로그인 유무 검증
+export const requireLogin = ({ user, router }: requireLoginParams) => {
+  if (!user) return router.push('/login-required');
+
+  return true;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,63 +1,64 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
-    darkMode: ["class"],
-    content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  safelist: ['dropdown-item'],
+  darkMode: ['class'],
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx,css}',
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		}
-  	}
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        chart: {
+          '1': 'hsl(var(--chart-1))',
+          '2': 'hsl(var(--chart-2))',
+          '3': 'hsl(var(--chart-3))',
+          '4': 'hsl(var(--chart-4))',
+          '5': 'hsl(var(--chart-5))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require('tailwindcss-animate')],
 };
 export default config;


### PR DESCRIPTION
1. 구인글 작성, 참가신청은 로그인이 필요한 서비스이기 때문에 로그인 검증 로직 추가
모달로 구현이 되어있기 때문에  protected route설정 불가하기 때문에
검증함수를 유틸함수로 분리하여 재사용

2. react-icons 라이브러리 설치하여 디스코드 아이콘 추가
3. 프로필링크에서 "내 모집글"링크 클릭시 탭 전환 되지않아서 쿼리파라미터 기준으로 전환 (소개탭은 쿼리파라미터x)
4. "내 모집글" → 생성한 파티 이름변경 및 참가중인 파티 추가 & 프로필 드롭다운 메뉴로 이동 


