### PR TITLE
Feat/header: 프로필 드롭 링크메뉴 공통컴포넌트화

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,9 +76,3 @@ body {
     @apply bg-background text-foreground;
   }
 }
-
-@layer components {
-  .dropdown-item {
-    @apply flex w-full items-center px-2 py-1.5 text-sm cursor-pointer hover:bg-[#eaf5ea] hover:text-[#206030];
-  }
-}

--- a/src/components/auth/DropdownLinkItem.tsx
+++ b/src/components/auth/DropdownLinkItem.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { DropdownMenuItem } from '../ui/dropdown-menu';
+import { ReactNode } from 'react';
+
+interface DropdownLinkItemProps {
+  href: string;
+  children: ReactNode;
+}
+
+const DropdownLinkItem = ({ href, children }: DropdownLinkItemProps) => {
+  return (
+    <DropdownMenuItem asChild>
+      <Link href={href} className="cursor-pointer focus:!text-[#206030]">
+        {children}
+      </Link>
+    </DropdownMenuItem>
+  );
+};
+
+export default DropdownLinkItem;

--- a/src/components/auth/UserDropdownButton.tsx
+++ b/src/components/auth/UserDropdownButton.tsx
@@ -54,8 +54,14 @@ const UserDropdownButton = ({ profile }: UserDropdownButtonProps) => {
         </DropdownLinkItem>
 
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
-          <Button onClick={handleLogOut}>로그아웃</Button>
+        <DropdownMenuItem asChild>
+          <Button
+            variant="ghost"
+            className="w-full justify-start px-2 cursor-pointer focus:text-[#206030]"
+            onClick={handleLogOut}
+          >
+            로그아웃
+          </Button>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/auth/UserDropdownButton.tsx
+++ b/src/components/auth/UserDropdownButton.tsx
@@ -2,6 +2,7 @@
 import { useSignOutMutation } from '@/query/auth/useAuthMutation';
 import { Profile } from '@/types/profiles.types';
 import { useRouter } from 'next/navigation';
+import ProfileAvatar from '../ProfileAvatar';
 import { Button } from '../ui/button';
 import {
   DropdownMenu,
@@ -10,8 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
-import Link from 'next/link';
-import ProfileAvatar from '../ProfileAvatar';
+import DropdownLinkItem from './DropdownLinkItem';
 
 interface UserDropdownButtonProps {
   profile: Profile;
@@ -41,30 +41,18 @@ const UserDropdownButton = ({ profile }: UserDropdownButtonProps) => {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        <DropdownMenuItem className="hover:text-[#206030]" asChild>
-          <Link
-            href={`/profile/${profile.id}`}
-            className="cursor-pointer hover:text-[#206030]"
-          >
-            프로필
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link
-            href={`/profile/${profile?.id}?tab=created`}
-            className="dropdown-item"
-          >
-            생성한 파티
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link
-            href={`/profile/${profile?.id}?tab=joined`}
-            className="dropdown-item"
-          >
-            참가중인 파티
-          </Link>
-        </DropdownMenuItem>
+        <DropdownLinkItem href={`/profile/${profile.id}`}>
+          프로필
+        </DropdownLinkItem>
+
+        <DropdownLinkItem href={`/profile/${profile?.id}?tab=created`}>
+          생성한 파티
+        </DropdownLinkItem>
+
+        <DropdownLinkItem href={`/profile/${profile?.id}?tab=joined`}>
+          참가중인 파티
+        </DropdownLinkItem>
+
         <DropdownMenuSeparator />
         <DropdownMenuItem>
           <Button onClick={handleLogOut}>로그아웃</Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,56 +1,56 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : 'button';
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };


### PR DESCRIPTION
- 프로필 드롭 링크 메뉴 공통 컴포넌트화 하여 스타일 통일
- 프로필 링크로 이동 후 focus 흔적 남는것 제거
- 로그아웃 버튼도 위 링크 메뉴 스타일에 맞춤
