### PR TITLE
fix: modal/select 오픈시 오른쪽 여백 보정(react-remove-scroll) 제거

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,7 @@
   If we ever want to remove these styles, we need to add an explicit border
   color utility to any element that depends on these defaults.
 */
+
 @layer base {
   *,
   ::after,
@@ -93,4 +94,8 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+body[data-scroll-locked] {
+  margin-right: 0 !important;
 }


### PR DESCRIPTION
- shadcn/ui의 Select 컴포넌트는 radix기반 컴포넌트.
- 내부에서 react-remove-scroll을 실행함.
- select open시 스크롤 잠금
- 스크롤잠금시 스크롤 너비만큼의 흰띠의 여백이 생김(스크롤 여백 보정)
- margin-right 0값을 줘서 보정을 끔