### PR TITLE
Fix/party dialog redirect open: 구인글 상세보기 open시 recruit페이지로만 이동되는 문제 해결

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,7 @@
   If we ever want to remove these styles, we need to add an explicit border
   color utility to any element that depends on these defaults.
 */
+
 @layer base {
   *,
   ::after,
@@ -93,4 +94,8 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+body[data-scroll-locked] {
+  margin-right: 0 !important;
 }

--- a/src/components/recruit/PartyDialog.tsx
+++ b/src/components/recruit/PartyDialog.tsx
@@ -16,9 +16,10 @@ import PartyDetail from './PartyDetail';
 interface PartyDialogProps {
   party: RecruitWithProfile;
   searchParams: URLSearchParams;
+  pathName: string;
 }
 
-const PartyDialog = ({ party, searchParams }: PartyDialogProps) => {
+const PartyDialog = ({ party, searchParams, pathName }: PartyDialogProps) => {
   const router = useRouter();
 
   const isOpen = party.id === searchParams.get('id'); // open상태 결정
@@ -32,7 +33,7 @@ const PartyDialog = ({ party, searchParams }: PartyDialogProps) => {
 
     if (!open) params.delete('id');
 
-    router.replace(`/recruit?${params.toString()}`, { scroll: false });
+    router.replace(`${pathName}?${params.toString()}`, { scroll: false });
   };
 
   return (

--- a/src/components/recruit/PartyList.tsx
+++ b/src/components/recruit/PartyList.tsx
@@ -2,7 +2,7 @@
 
 import { RecruitWithProfile } from '@/types/parties.types';
 import PartyDialog from './PartyDialog';
-import { useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import ScrollToTopButton from '../ScrollToTopButton';
 
 interface PartyListProps {
@@ -12,6 +12,7 @@ interface PartyListProps {
 const PartyList = ({ parties }: PartyListProps) => {
   // 여기서 한번만 실행하고 props로 전달
   const searchParams = useSearchParams();
+  const pathName = usePathname();
 
   return (
     <section className="relative">
@@ -19,7 +20,11 @@ const PartyList = ({ parties }: PartyListProps) => {
       <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 py-3">
         {parties?.map((party) => (
           <li key={party.id}>
-            <PartyDialog party={party} searchParams={searchParams} />
+            <PartyDialog
+              party={party}
+              searchParams={searchParams}
+              pathName={pathName}
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
usePathname훅을 사용하여 해당 경로 유지하여 모달 open

ex) 프로필페이지의 참여중인 파티목록에서 해당 구인글 클릭시 recruit페이지로 이동되어 open되었음.

