### PR TITLE
fix: [style]속성 선택자 추가하여 우선순위 올리기 - 스크롤바 여백

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,6 +96,6 @@
   }
 }
 
-body[data-scroll-locked] {
+body[data-scroll-locked][style] {
   margin-right: 0 !important;
 }


### PR DESCRIPTION
shadcn/ui의 select,dialog등 컴포넌트는 `react-remove-scroll` 라이브러리를 사용중임.
때문에 open시 body에 [data-scroll-locked] 속성이 추가됨.
body[data-scroll-locked] 스타일이 적용이 되어있음(라이브러리)

[style] 속성 선택자를 추가함으로써 특이성을 올려 margin-right값을 덮어씌워씀