### PR TITLE
feat: 참가자목록 실시간적용

### DIFF
--- a/src/components/recruit/PartyDetail.tsx
+++ b/src/components/recruit/PartyDetail.tsx
@@ -26,6 +26,7 @@ import TooltipWrapper from '../TooltipWrapper';
 import { Button } from '../ui/button';
 import { DialogClose } from '../ui/dialog';
 import OwnerActionButtons from './OwnerActionButtons';
+import { usePartyMembersRealtime } from '@/hooks/realtime/usePartyMembersRealtime';
 
 interface PartyDetailProps {
   recruit: RecruitWithProfile;
@@ -58,6 +59,9 @@ const PartyDetail = ({ recruit, isModal }: PartyDetailProps) => {
 
   // 구인글 끌어올리기
   const { mutate: raiseParty } = useRaisePartyMutation();
+
+  // 실시간 참가자 목록
+  usePartyMembersRealtime(recruit.id, isModal);
 
   // 로그인한 사용자가 작성자인지 확인
   const isOwner = recruit.created_by.id === currentUserId;

--- a/src/hooks/realtime/usePartyMembersRealtime.ts
+++ b/src/hooks/realtime/usePartyMembersRealtime.ts
@@ -1,0 +1,30 @@
+'use client';
+import { browserClient } from '@/utils/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+export const usePartyMembersRealtime = (partyId: string, isModal: boolean) => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!partyId || !isModal) return;
+
+    const membersChannel = browserClient
+      .channel(`party:${partyId}:members`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'party_member',
+          filter: `party_id=eq.${partyId}`,
+        },
+        () => queryClient.invalidateQueries({ queryKey: ['members', partyId] })
+      )
+      .subscribe();
+
+    return () => {
+      browserClient.removeChannel(membersChannel);
+    };
+  }, [partyId, isModal, queryClient]);
+};


### PR DESCRIPTION
모달 상세보기의 참가자 목록에 supabase Realtime 적용
JIT(Just In Time) 구독 - 모달열렸을때만 구독 닫히면 해제(필요할때만 구독)


delete이벤트에서는 payload에 PK만 들어와져서 filter의 party_id값으로 필터링이 불가하였음.
REPLICA IDENTITY FULL을 적용하여 모든 행들을 가져와 필터에서 평가할 수 있도록 설정함.

```sql
alter table party_member replica identity full;
```

(공식문서에 RLS가 활성화 되어있고 replica identity가 full로 설정되어 있을경우 pk만 노출된다고함
이유는 삭제된 레코드에 대한 사용자 접근 권한을 Postgres가 확인할 방법이 없기 때문입니다. 따라서 삭제 시에는 primary key만 남아서 어떤 레코드가 삭제되었는지를 추적하기 위해 사용됩니다. 라는데 보안문제인것 같음)

